### PR TITLE
Update URL for Chrome Dev Tools

### DIFF
--- a/units/2-HTML1/sessions/2-devTools/README.md
+++ b/units/2-HTML1/sessions/2-devTools/README.md
@@ -25,7 +25,7 @@
 
 ### References
 
-* [Chrome DevTools](https://developer.chrome.com/devtools)
+* [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools)
 
 ## During Class
 


### PR DESCRIPTION
The previous URL (https://developer.chrome.com/devtools) points to this new location with the message: "The DevTools docs have moved!
For the latest tutorials, docs and updates head over to the new home of Chrome DevTools".
